### PR TITLE
Fix routing on GitHub pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 .Ruserdata
 barebone_public_dashboard.Rproj
 cov19vaccsim.Rproj
-docs/404.html

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 barebone_public_dashboard.Rproj
 cov19vaccsim.Rproj
+.idea

--- a/Dashboard/angular.json
+++ b/Dashboard/angular.json
@@ -26,6 +26,7 @@
             "assets": [
               "src/favicon.ico",
               "src/assets",
+              "src/404.html",
               {
                 "glob": "**/*",
                 "input": "./data/",

--- a/Dashboard/src/404.html
+++ b/Dashboard/src/404.html
@@ -1,26 +1,17 @@
-<!doctype html>
-<html lang="de">
-<head>
-  <meta charset="utf-8">
-  <title>Simulation der COVID19-Impfkampagne</title>
-  <base href="/cov19vaccsim/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="index, follow">
-  <meta name="og:title" content="Simulation der COVID19-Impfkampagne">
-  <meta name="og:url" content="https://www.zidatasciencelab.de/cov19vaccsim/">
-  <meta name="twitter:text:title" content="Simulation der COVID19-Impfkampagne">
-  <meta name="description" content="Simulation der COVID19-Impfkampagne">
-  <meta name="og:description" content="Simulation der COVID19-Impfkampagne">
-  <meta name="og:image" content="https://www.zidatasciencelab.de/cov19vaccsim/assets/logo_zi.png">
-  <meta name="og:image:secure_url" content="https://www.zidatasciencelab.de/cov19vaccsim/assets/logo_zi.png">
-  <meta name="twitter:image" content="https://www.zidatasciencelab.de/cov19vaccsim/assets/logo_zi.png">
-  <link rel="icon" type="image/x-icon" href="https://www.zidatasciencelab.de/cov19vaccsim/assets/logo_zi.png">
-  <link rel="apple-touch-icon" href="https://www.zidatasciencelab.de/cov19vaccsim/assets/logo_zi.png">
-  <link rel="canonical" href="https://www.zidatasciencelab.de/cov19vaccsim/"/>
-  <meta name="theme-color" content="#388e3c">
-  <link rel="icon" type="image/x-icon" href="https://www.zidatasciencelab.de/cov19vaccsim/assets/logo_zi.png">  
-<link rel="stylesheet" href="styles.ca73cb9183d250003052.css"></head>
-<body>
-  <app-root></app-root>
-<script src="runtime.0e49e2b53282f40c8925.js" defer></script><script src="polyfills.2e89f9530eab053a7df4.js" defer></script><script src="main.d3efd9adca795a4cb0f7.js" defer></script></body>
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>404 Redirect</title>
+    </head>
+    <body>
+        <script>
+            const path = window.location.pathname.slice(1);
+            localStorage.setItem('coming-from', path);
+            console.log('Setting redirect request to', path);
+            window.location.href = 'https://cov19-impfvorhersage.github.io/cov19vaccsim/';
+        </script>
+        <div>
+            Redirecting to base url: https://cov19-impfvorhersage.github.io/cov19vaccsim/
+        </div>
+    </body>
 </html>

--- a/Dashboard/src/app/app.component.ts
+++ b/Dashboard/src/app/app.component.ts
@@ -1,32 +1,23 @@
-import { Component , OnInit} from '@angular/core';
-import { ApiService } from './services/api.service';
-import { AuthService } from './services/auth.service';
-import {MatIconRegistry} from '@angular/material/icon';
-import {DomSanitizer} from '@angular/platform-browser';
-
+import { Component } from '@angular/core';
+import { MatIconRegistry } from '@angular/material/icon';
+import { DomSanitizer } from '@angular/platform-browser';
 
 @Component({
-  selector: 'app-root',
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+    selector: 'app-root',
+    templateUrl: './app.component.html',
+    styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  title = 'COVID-19 Impfkampagne in Deutschland';
+    title = 'COVID-19 Impfkampagne in Deutschland';
 
-  constructor(
-    iconRegistry: MatIconRegistry,
-    sanitizer: DomSanitizer
-  ) {
-      iconRegistry.addSvgIcon(
-          'github',
-          sanitizer.bypassSecurityTrustResourceUrl('assets/img/GitHub-Mark.svg'));
-  }
-
-  ngOnInit() {
-  }
-
-
-  logout(){
-  }
+    constructor(
+        iconRegistry: MatIconRegistry,
+        sanitizer: DomSanitizer
+    ) {
+        iconRegistry.addSvgIcon(
+            'github',
+            sanitizer.bypassSecurityTrustResourceUrl('assets/img/GitHub-Mark.svg')
+        );
+    }
 
 }

--- a/Dashboard/src/app/app.component.ts
+++ b/Dashboard/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
-import { MatIconRegistry } from '@angular/material/icon';
+import { Router } from '@angular/router';
 import { DomSanitizer } from '@angular/platform-browser';
+import { MatIconRegistry } from '@angular/material/icon';
 
 @Component({
     selector: 'app-root',
@@ -12,12 +13,24 @@ export class AppComponent {
 
     constructor(
         iconRegistry: MatIconRegistry,
-        sanitizer: DomSanitizer
+        sanitizer: DomSanitizer,
+        router: Router
     ) {
         iconRegistry.addSvgIcon(
             'github',
             sanitizer.bypassSecurityTrustResourceUrl('assets/img/GitHub-Mark.svg')
         );
+
+        // check for scheduled redirects (github-pages specific)
+        let comingFrom = localStorage.getItem('coming-from');
+        if (comingFrom) {
+            localStorage.removeItem('coming-from');
+            comingFrom = comingFrom.replace('cov19vaccsim/', './');
+            console.log(`Found redirect request to ${comingFrom}. Redirecting...`);
+            router.navigate([comingFrom]).catch(error => {
+                console.warn(`Redirect to ${comingFrom} failed!`, error);
+            });
+        }
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ First launch only:
 Build for github-pages
 
 `ng build --prod --base-href "/cov19vaccsim/"`
-`cp ../docs/index.html ../docs/404.html`
 
 The angular.json assumes that doc is the desired output dir.
 


### PR DESCRIPTION
Links like [this](https://cov19-impfvorhersage.github.io/cov19vaccsim/total-deliveries) should now work on the deployed GitHub page.
